### PR TITLE
07deno-book-shared.php: show https://deno.pg4e.com in hidden.py excerpt

### DIFF
--- a/tools/deno/07deno-book-shared.php
+++ b/tools/deno/07deno-book-shared.php
@@ -28,7 +28,7 @@ $oldgrade = $RESULT->grade;
 
 $url = isset($_REQUEST['url']) ? $_REQUEST['url'] : "";
 $url = rtrim(trim($url), '/');
-$sampleurl = "https://comfortable-starling-12.deno.dev";
+$sampleurl = "https://deno.pg4e.com";
 
 if ( strlen($url) > 0 ) $sampleurl = $url;
 


### PR DESCRIPTION
### Problem
`tools/deno/07deno-book-shared.php` still displays `https://comfortable-starling-12.deno.dev` in the *hidden.py* code excerpt, even though the assignment is meant to use the shared Deno KV service at `https://deno.pg4e.com`. Students who copy‑paste this excerpt submit the wrong URL and the autograder fails.

### Fix
Replace the default `$sampleurl` with the correct shared‑server URL:

```diff
-$sampleurl = "https://comfortable-starling-12.deno.dev";
+$sampleurl = "https://deno.pg4e.com";
```

`07deno-text-shared.php` already uses `https://deno.pg4e.com` as the `$sampleurl`, so this change
brings the two shared‑server assignments into sync.

### Before (screenshot):
<img width="1164" height="409" alt="Screenshot 2025-08-05 at 9 11 50 PM" src="https://github.com/user-attachments/assets/0df5f395-63e3-4953-aed8-b39a85cdf2a1" />

### After (screenshot):

<img width="1443" height="341" alt="Screenshot 2025-08-05 at 9 53 30 PM" src="https://github.com/user-attachments/assets/d3ef2129-c7be-4248-a59a-2683eaa48f6b" />

The after screenshot above is from `07deno-book-shared.php` running locally on MAMP with mocked dependencies, without Tsugi or styling from the PG4E site.
